### PR TITLE
Add page.querySelector(...).click() to the Script PoC

### DIFF
--- a/PipeableTests/ScriptTests.swift
+++ b/PipeableTests/ScriptTests.swift
@@ -22,7 +22,35 @@ final class ScriptTests: XCTestCase {
             _ = try await runScript(script)
             XCTFail("An empty url error is expected")
         } catch let ScriptError.error(reason) {
-            XCTAssertEqual(reason, "Empty url parameter")
+            XCTAssertEqual(reason, "Bad url.")
+        } catch {
+            XCTFail("An empty url error is expected")
+        }
+    }
+
+    func test_querySelector_and_click() async throws {
+        let script = """
+            const element = await page.querySelector("asd");
+            await element.click();
+            return element;
+        """
+        let result = try await runScript(script)
+        // swiftlint:disable:next force_cast
+        let element = result.toObjectOf(PipeableElementWrapper.self) as! PipeableElementWrapper
+        XCTAssertEqual(element.successFullClicksClount, 1)
+    }
+
+    func test_querySelector_and_click_with_error() async throws {
+        let script = """
+            const element = await page.querySelector("empty");
+            await element.click();
+            return element;
+        """
+        do {
+            _ = try await runScript(script)
+            XCTFail("Element not found error is expected")
+        } catch let ScriptError.error(reason) {
+            XCTAssertEqual(reason, "Element not found.")
         } catch {
             XCTFail("An empty url error is expected")
         }

--- a/Sources/PipeableSDK/Script/Script.swift
+++ b/Sources/PipeableSDK/Script/Script.swift
@@ -82,13 +82,11 @@ class PipeableElementWrapper: NSObject, PipeableElementJSExport {
     }
 
     func clickWithCompletion(_ completionHandler: JSValue) {
-        print("entering")
         dispatchGroup.enter()
 
         @Sendable
         func taskRun() async {
             defer {
-                print("leaving")
                 self.dispatchGroup.leave()
             }
             do {
@@ -124,13 +122,11 @@ class PageWrapper: NSObject, PageJSExport {
     }
 
     func gotoWithCompletion(_ url: String, _ completionHandler: JSValue) {
-        print("entering")
         dispatchGroup.enter()
 
         @Sendable
         func taskRun() async {
             defer {
-                print("leaving")
                 self.dispatchGroup.leave()
             }
             do {
@@ -148,13 +144,11 @@ class PageWrapper: NSObject, PageJSExport {
     }
 
     func querySelectorWithCompletion(_ selector: String, _ completionHandler: JSValue) {
-        print("entering")
         dispatchGroup.enter()
 
         @Sendable
         func taskRun() async {
             defer {
-                print("leaving")
                 self.dispatchGroup.leave()
             }
             do {


### PR DESCRIPTION
Add a more complex use case for the Script mock that returns a native object (PipeableElement).

During the implementation, found a way to properly use the wrappers prototypes. Refactored the code to add JS functions using the PageWrapper.prototype.

This should be the final PR for the PoC stage. Next PRs will focus on the actual implementation.