### PR TITLE
Refactor script wrappers to minimize code duplication

### DIFF
--- a/PipeableSDK.xcodeproj/project.pbxproj
+++ b/PipeableSDK.xcodeproj/project.pbxproj
@@ -14,6 +14,12 @@
 		A4A7A9312B56BD7500982E63 /* PipeableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4A7A9302B56BD7500982E63 /* PipeableTests.swift */; };
 		A4A7A9322B56BD7500982E63 /* Pipeable.h in Headers */ = {isa = PBXBuildFile; fileRef = A4A7A9242B56BD7500982E63 /* Pipeable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A4C365FC2B62A3C5000D3F50 /* sophia.js in Resources */ = {isa = PBXBuildFile; fileRef = A4C365FB2B62A3C5000D3F50 /* sophia.js */; };
+		E81BD5AA2B6D4233007DFC02 /* BaseWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81BD5A92B6D4233007DFC02 /* BaseWrapper.swift */; };
+		E81BD5AE2B6D430A007DFC02 /* PageWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81BD5AD2B6D430A007DFC02 /* PageWrapper.swift */; };
+		E81BD5B02B6D45B6007DFC02 /* ElementWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81BD5AF2B6D45B6007DFC02 /* ElementWrapper.swift */; };
+		E81BD5B42B6D4963007DFC02 /* PageScript_GotoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81BD5B32B6D4963007DFC02 /* PageScript_GotoTests.swift */; };
+		E81BD5B62B6D5092007DFC02 /* Fakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81BD5B52B6D5092007DFC02 /* Fakes.swift */; };
+		E832B5CC2B6D411900791C57 /* ScriptContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E832B5CB2B6D411900791C57 /* ScriptContext.swift */; };
 		E8AC39A52B615C1D00D413BF /* Script.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8AC39A42B615C1D00D413BF /* Script.swift */; };
 		E8F7B28E2B639E160040B77B /* ScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F7B28C2B639E160040B77B /* ScriptTests.swift */; };
 /* End PBXBuildFile section */
@@ -39,6 +45,12 @@
 		A4A7A92B2B56BD7500982E63 /* PipeableSDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PipeableSDKTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A4A7A9302B56BD7500982E63 /* PipeableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipeableTests.swift; sourceTree = "<group>"; };
 		A4C365FB2B62A3C5000D3F50 /* sophia.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = sophia.js; sourceTree = "<group>"; };
+		E81BD5A92B6D4233007DFC02 /* BaseWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseWrapper.swift; sourceTree = "<group>"; };
+		E81BD5AD2B6D430A007DFC02 /* PageWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageWrapper.swift; sourceTree = "<group>"; };
+		E81BD5AF2B6D45B6007DFC02 /* ElementWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementWrapper.swift; sourceTree = "<group>"; };
+		E81BD5B32B6D4963007DFC02 /* PageScript_GotoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageScript_GotoTests.swift; sourceTree = "<group>"; };
+		E81BD5B52B6D5092007DFC02 /* Fakes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fakes.swift; sourceTree = "<group>"; };
+		E832B5CB2B6D411900791C57 /* ScriptContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ScriptContext.swift; path = Sources/PipeableSDK/ScriptContext.swift; sourceTree = SOURCE_ROOT; };
 		E8AC39A42B615C1D00D413BF /* Script.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Script.swift; sourceTree = "<group>"; };
 		E8F7B28C2B639E160040B77B /* ScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -113,6 +125,7 @@
 				E8F7B28C2B639E160040B77B /* ScriptTests.swift */,
 				A40EAC682B6BC88B00A6B6B3 /* PipeableXCTestCase.swift */,
 				A40EAC6B2B6BD0A100A6B6B3 /* PipeablePage_GotoTests.swift */,
+				E81BD5B32B6D4963007DFC02 /* PageScript_GotoTests.swift */,
 			);
 			path = PipeableTests;
 			sourceTree = "<group>";
@@ -131,6 +144,11 @@
 			isa = PBXGroup;
 			children = (
 				E8AC39A42B615C1D00D413BF /* Script.swift */,
+				E832B5CB2B6D411900791C57 /* ScriptContext.swift */,
+				E81BD5A92B6D4233007DFC02 /* BaseWrapper.swift */,
+				E81BD5AD2B6D430A007DFC02 /* PageWrapper.swift */,
+				E81BD5AF2B6D45B6007DFC02 /* ElementWrapper.swift */,
+				E81BD5B52B6D5092007DFC02 /* Fakes.swift */,
 			);
 			path = Script;
 			sourceTree = "<group>";
@@ -289,8 +307,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E81BD5B62B6D5092007DFC02 /* Fakes.swift in Sources */,
+				E81BD5AA2B6D4233007DFC02 /* BaseWrapper.swift in Sources */,
+				E832B5CC2B6D411900791C57 /* ScriptContext.swift in Sources */,
 				A4A7A9262B56BD7500982E63 /* Pipeable.docc in Sources */,
 				E8AC39A52B615C1D00D413BF /* Script.swift in Sources */,
+				E81BD5AE2B6D430A007DFC02 /* PageWrapper.swift in Sources */,
+				E81BD5B02B6D45B6007DFC02 /* ElementWrapper.swift in Sources */,
 				A434C6162B5964B300B8011C /* Pipeable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -302,6 +325,7 @@
 				A40EAC692B6BC88B00A6B6B3 /* PipeableXCTestCase.swift in Sources */,
 				A40EAC6C2B6BD0A100A6B6B3 /* PipeablePage_GotoTests.swift in Sources */,
 				E8F7B28E2B639E160040B77B /* ScriptTests.swift in Sources */,
+				E81BD5B42B6D4963007DFC02 /* PageScript_GotoTests.swift in Sources */,
 				A4A7A9312B56BD7500982E63 /* PipeableTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PipeableTests/PageScript_GotoTests.swift
+++ b/PipeableTests/PageScript_GotoTests.swift
@@ -1,0 +1,40 @@
+@testable import PipeableSDK
+import WebKit
+import XCTest
+
+final class PageScriptGotoTests: PipeableXCTestCase {
+    func testGotoWithAboutBlank() async throws {
+        let page = PipeablePage(webView)
+        let result = try await runScript(
+            """
+            await page.goto("about:blank");
+            return page.url();
+            """,
+            page)
+
+        // TODO: How do we handle return values from scripts?!?
+        // swiftlint:disable:next force_cast
+        let url = result.toObject() as! URL
+        XCTAssertEqual(url.absoluteString, "about:blank")
+    }
+
+    func testGotoWithBadUrl() async throws {
+        let page = PipeablePage(webView)
+
+        do {
+            _ = try await runScript(
+                """
+                await page.goto("blank");
+                """,
+                page)
+            XCTFail("Expected an error, but no error was thrown.")
+        } catch {
+            // TODO: Should we map back to PipeableError in the scripts?!?
+            if case ScriptError.error = error {
+                return
+            } else {
+                XCTFail("Expected ScriptError.error, but got a different error: \(error)")
+            }
+        }
+    }
+}

--- a/PipeableTests/ScriptTests.swift
+++ b/PipeableTests/ScriptTests.swift
@@ -22,7 +22,7 @@ final class ScriptTests: XCTestCase {
             _ = try await runScript(script)
             XCTFail("An empty url error is expected")
         } catch let ScriptError.error(reason) {
-            XCTAssertEqual(reason, "Empty url")
+            XCTAssertEqual(reason, "Navigation error: Empty url")
         } catch {
             XCTFail("An empty url error is expected")
         }

--- a/PipeableTests/ScriptTests.swift
+++ b/PipeableTests/ScriptTests.swift
@@ -5,7 +5,7 @@ final class ScriptTests: XCTestCase {
     func test_goto() async throws {
         let result = try await runScript("""
             print('Calling page.goto');
-            await page.goto("https://google.com");
+            await fakePage.goto("https://google.com");
             return true;
         """)
 
@@ -15,7 +15,7 @@ final class ScriptTests: XCTestCase {
     func test_goto_with_error() async throws {
         let script = """
             print('Calling page.goto');
-            await page.goto("");
+            await fakePage.goto("");
             return true;
         """
         do {
@@ -30,19 +30,19 @@ final class ScriptTests: XCTestCase {
 
     func test_querySelector_and_click() async throws {
         let script = """
-            const element = await page.querySelector("asd");
+            const element = await fakePage.querySelector("asd");
             await element.click();
             return element;
         """
         let result = try await runScript(script)
         // swiftlint:disable:next force_cast
-        let element = result.toObjectOf(PipeableElementWrapper.self) as! PipeableElementWrapper
+        let element = result.toObjectOf(FakeElementWrapper.self) as! FakeElementWrapper
         XCTAssertEqual(element.successFullClicksClount, 1)
     }
 
     func test_querySelector_and_click_with_error() async throws {
         let script = """
-            const element = await page.querySelector("empty");
+            const element = await fakePage.querySelector("empty");
             await element.click();
             return element;
         """

--- a/Sources/PipeableSDK/Script/BaseWrapper.swift
+++ b/Sources/PipeableSDK/Script/BaseWrapper.swift
@@ -1,0 +1,48 @@
+import Foundation
+import JavaScriptCore
+
+enum CompletionResult {
+    case error(String)
+    case success(NSObject?)
+}
+
+class BaseWrapper: NSObject {
+    let dispatchGroup: DispatchGroup
+    init(_ dispatchGroup: DispatchGroup) {
+        self.dispatchGroup = dispatchGroup
+        super.init()
+    }
+
+    func doWithCompletion(_ completionHandler: JSValue, _ call: @escaping () async throws -> CompletionResult) {
+        dispatchGroup.enter()
+
+        @Sendable
+        func taskRun() async {
+            defer {
+                self.dispatchGroup.leave()
+            }
+            do {
+                let result = try await call()
+                switch result {
+                case let .error(error):
+                    completionHandler.call(withArguments: [["error": error]])
+                case let .success(result):
+                    if let result = result {
+                        completionHandler.call(withArguments: [["result": result]])
+                    } else {
+                        completionHandler.call(withArguments: [[:]])
+                    }
+                }
+            } catch let PipeableError.navigationError(errorMessage) {
+                completionHandler.call(withArguments: [["error": "Navigation error: \(errorMessage)"]])
+            } catch PipeableError.elementNotFound {
+                completionHandler.call(withArguments: [["error": "Element not found."]])
+            } catch {
+                completionHandler.call(withArguments: [["error": "Unexpected error \(error)"]])
+            }
+        }
+        Task {
+            await taskRun()
+        }
+    }
+}

--- a/Sources/PipeableSDK/Script/ElementWrapper.swift
+++ b/Sources/PipeableSDK/Script/ElementWrapper.swift
@@ -1,0 +1,22 @@
+import Foundation
+import JavaScriptCore
+
+@objc protocol ElementJSExport: JSExport {
+    func clickWithCompletion(_ completionHandler: JSValue)
+}
+
+class ElementWrapper: BaseWrapper, ElementJSExport {
+    let element: PipeableElement
+
+    init(_ dispatchGroup: DispatchGroup, _ element: PipeableElement) {
+        self.element = element
+        super.init(dispatchGroup)
+    }
+
+    func clickWithCompletion(_ completionHandler: JSValue) {
+        doWithCompletion(completionHandler) {
+            try await self.element.click()
+            return CompletionResult.success(nil)
+        }
+    }
+}

--- a/Sources/PipeableSDK/Script/ElementWrapper.swift
+++ b/Sources/PipeableSDK/Script/ElementWrapper.swift
@@ -5,7 +5,7 @@ import JavaScriptCore
     func clickWithCompletion(_ completionHandler: JSValue)
 }
 
-class ElementWrapper: BaseWrapper, ElementJSExport {
+final class ElementWrapper: BaseWrapper, ElementJSExport {
     let element: PipeableElement
 
     init(_ dispatchGroup: DispatchGroup, _ element: PipeableElement) {

--- a/Sources/PipeableSDK/Script/Fakes.swift
+++ b/Sources/PipeableSDK/Script/Fakes.swift
@@ -1,0 +1,98 @@
+import Foundation
+import JavaScriptCore
+
+// Fakes are temporary used for testing. Will be removed soon.
+
+class FakePage {
+    func goto(_ url: String) async throws {
+        if url.isEmpty {
+            throw PipeableError.navigationError("Empty url")
+        }
+        print("Navigating to url: \(url) ...")
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        print("Navigation completed!")
+    }
+
+    public func querySelector(_ selector: String) async throws -> FakePipeableElement? {
+        if selector.isEmpty {
+            return nil
+        }
+        if selector == "empty" {
+            return FakePipeableElement(self, "")
+        }
+        return FakePipeableElement(self, "id-123")
+    }
+}
+
+class FakePipeableElement {
+    var page: FakePage
+    let elementId: String
+
+    init(_ page: FakePage, _ elementId: String) {
+        self.page = page
+        self.elementId = elementId
+    }
+
+    public func click() async throws {
+        if elementId.isEmpty {
+            throw PipeableError.elementNotFound
+        }
+        print("Clicking on element with id: \(elementId) ...")
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        print("Click completed!")
+    }
+}
+
+@objc protocol FakeElementJSExport: JSExport {
+    func clickWithCompletion(_ completionHandler: JSValue)
+}
+
+class FakeElementWrapper: BaseWrapper, FakeElementJSExport {
+    let element: FakePipeableElement
+    var successFullClicksClount = 0
+
+    init(_ dispatchGroup: DispatchGroup, _ element: FakePipeableElement) {
+        self.element = element
+        super.init(dispatchGroup)
+    }
+
+    func clickWithCompletion(_ completionHandler: JSValue) {
+        doWithCompletion(completionHandler) {
+            try await self.element.click()
+            self.successFullClicksClount += 1
+            return CompletionResult.success(nil)
+        }
+    }
+}
+
+@objc protocol FakePageJSExport: JSExport {
+    func gotoWithCompletion(_ url: String, _ completionHandler: JSValue)
+    func querySelectorWithCompletion(_ selector: String, _ completionHandler: JSValue)
+}
+
+// Page wrapper wraps the Page Swift API so that it makes it easy/possible to implement the Page Script API.
+class FakePageWrapper: BaseWrapper, FakePageJSExport {
+    let page: FakePage
+
+    override init(_ dispatchGroup: DispatchGroup) {
+        self.page = FakePage()
+        super.init(dispatchGroup)
+    }
+
+    func gotoWithCompletion(_ url: String, _ completionHandler: JSValue) {
+        doWithCompletion(completionHandler) {
+            try await self.page.goto(url)
+            return CompletionResult.success(nil)
+        }
+    }
+
+    func querySelectorWithCompletion(_ selector: String, _ completionHandler: JSValue) {
+        doWithCompletion(completionHandler) {
+            let element = try await self.page.querySelector(selector)
+            if let element = element {
+                return CompletionResult.success(FakeElementWrapper(self.dispatchGroup, element))
+            }
+            return CompletionResult.success(nil)
+        }
+    }
+}

--- a/Sources/PipeableSDK/Script/PageWrapper.swift
+++ b/Sources/PipeableSDK/Script/PageWrapper.swift
@@ -1,0 +1,39 @@
+import Foundation
+import JavaScriptCore
+
+@objc protocol PageJSExport: JSExport {
+    func gotoWithCompletion(_ url: String, _ completionHandler: JSValue)
+    func querySelectorWithCompletion(_ selector: String, _ completionHandler: JSValue)
+    func url() -> URL?
+}
+
+// Page wrapper wraps the Page Swift API so that it makes it easy/possible to implement the Page Script API.
+class PageWrapper: BaseWrapper, PageJSExport {
+    let page: PipeablePage
+
+    init(_ dispatchGroup: DispatchGroup, _ page: PipeablePage) {
+        self.page = page
+        super.init(dispatchGroup)
+    }
+
+    func gotoWithCompletion(_ url: String, _ completionHandler: JSValue) {
+        doWithCompletion(completionHandler) {
+            try await self.page.goto(url)
+            return CompletionResult.success(nil)
+        }
+    }
+
+    func querySelectorWithCompletion(_ selector: String, _ completionHandler: JSValue) {
+        doWithCompletion(completionHandler) {
+            let element = try await self.page.querySelector(selector)
+            if let element = element {
+                return CompletionResult.success(ElementWrapper(self.dispatchGroup, element))
+            }
+            return CompletionResult.success(nil)
+        }
+    }
+
+    func url() -> URL? {
+        return page.url()
+    }
+}

--- a/Sources/PipeableSDK/Script/PageWrapper.swift
+++ b/Sources/PipeableSDK/Script/PageWrapper.swift
@@ -8,7 +8,7 @@ import JavaScriptCore
 }
 
 // Page wrapper wraps the Page Swift API so that it makes it easy/possible to implement the Page Script API.
-class PageWrapper: BaseWrapper, PageJSExport {
+final class PageWrapper: BaseWrapper, PageJSExport {
     let page: PipeablePage
 
     init(_ dispatchGroup: DispatchGroup, _ page: PipeablePage) {

--- a/Sources/PipeableSDK/ScriptContext.swift
+++ b/Sources/PipeableSDK/ScriptContext.swift
@@ -1,0 +1,25 @@
+import JavaScriptCore
+
+@objc protocol ScriptContextJSExport: JSExport {
+    func scriptStarted()
+    func scriptEnded()
+}
+
+class ScriptContext: NSObject, ScriptContextJSExport {
+    let dispatchGroup: DispatchGroup
+
+    init(_ dispatchGroup: DispatchGroup) {
+        self.dispatchGroup = dispatchGroup
+        super.init()
+    }
+
+    func scriptStarted() {
+        dispatchGroup.enter()
+    }
+
+    func scriptEnded() {
+        Task {
+            self.dispatchGroup.leave()
+        }
+    }
+}

--- a/Sources/PipeableSDK/ScriptContext.swift
+++ b/Sources/PipeableSDK/ScriptContext.swift
@@ -5,7 +5,7 @@ import JavaScriptCore
     func scriptEnded()
 }
 
-class ScriptContext: NSObject, ScriptContextJSExport {
+final class ScriptContext: NSObject, ScriptContextJSExport {
     let dispatchGroup: DispatchGroup
 
     init(_ dispatchGroup: DispatchGroup) {


### PR DESCRIPTION
Create a base class for Pipeable wrappers and extract logic there. Simplify the JS code wrappers and extract reusable function.

Create real Page and Element wrappers and add the same test as Pipeable base classes.
