### PR TITLE
Use macos-14 (beta) to speed up CI builds

### DIFF
--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -49,7 +49,7 @@ jobs:
 
 
   build-and-test-sample-app:
-    runs-on: macos-13
+    runs-on: macos-14
 
     steps:
       - name: checkout repository
@@ -66,6 +66,9 @@ jobs:
       - name: Set Xcode 15
         run: |
           sudo xcode-select -switch /Applications/Xcode_15.1.app
+
+      - name: Install SwiftLint
+        run: brew install swiftlint
 
       - name: Swift Lint
         run: swiftlint --strict

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -27,12 +27,14 @@ jobs:
         run: |
           sudo xcode-select -switch /Applications/Xcode_15.2.app
 
-      # Disable for testing.
-      # - name: Swift Lint
-      #   run: swiftlint --strict
+      - name: Install SwiftLint
+        run: brew install swiftlint
 
-      # - name: Swift Format
-      #   run: swiftformat .
+      - name: Swift Lint
+        run: swiftlint --strict
+
+      - name: Swift Format
+        run: swiftformat .
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-and-test-framework:
-    runs-on: macos-13
+    runs-on: macos-14
 
     steps:
       - name: checkout repository

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -25,13 +25,14 @@ jobs:
 
       - name: Set Xcode 15
         run: |
-          sudo xcode-select -switch /Applications/Xcode_15.1.app
+          sudo xcode-select -switch /Applications/Xcode_15.2.app
 
-      - name: Swift Lint
-        run: swiftlint --strict
+      # Disable for testing.
+      # - name: Swift Lint
+      #   run: swiftlint --strict
 
-      - name: Swift Format
-        run: swiftformat .
+      # - name: Swift Format
+      #   run: swiftformat .
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
`macos-14` use M1 instances and seem to be much faster:
* 10 vs 3 mins for running the tests.
* 3 vs 1 min for compiling the samples.

It is beta but I think we can live with that.