### PR TITLE
Adding timeout to PipeablePage.waitForURL

### DIFF
--- a/PipeableSDK.xcodeproj/project.pbxproj
+++ b/PipeableSDK.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		A40BE0962B8393A800906441 /* PageLoadState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40BE0952B8393A800906441 /* PageLoadState.swift */; };
 		A40BE0992B83946800906441 /* PageLoadStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40BE0972B8393F500906441 /* PageLoadStateTests.swift */; };
+		A40BE09B2B84B59F00906441 /* PipeablePage_WaitForURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40BE09A2B84B59F00906441 /* PipeablePage_WaitForURLTests.swift */; };
 		A40EAC692B6BC88B00A6B6B3 /* PipeableXCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40EAC682B6BC88B00A6B6B3 /* PipeableXCTestCase.swift */; };
 		A40EAC6C2B6BD0A100A6B6B3 /* PipeablePage_GotoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40EAC6B2B6BD0A100A6B6B3 /* PipeablePage_GotoTests.swift */; };
 		A41D866F2B73D47400F24064 /* PipeableElement_ClickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41D866E2B73D47400F24064 /* PipeableElement_ClickTests.swift */; };
@@ -42,6 +43,7 @@
 /* Begin PBXFileReference section */
 		A40BE0952B8393A800906441 /* PageLoadState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageLoadState.swift; sourceTree = "<group>"; };
 		A40BE0972B8393F500906441 /* PageLoadStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageLoadStateTests.swift; sourceTree = "<group>"; };
+		A40BE09A2B84B59F00906441 /* PipeablePage_WaitForURLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PipeablePage_WaitForURLTests.swift; sourceTree = "<group>"; };
 		A40EAC682B6BC88B00A6B6B3 /* PipeableXCTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipeableXCTestCase.swift; sourceTree = "<group>"; };
 		A40EAC6B2B6BD0A100A6B6B3 /* PipeablePage_GotoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipeablePage_GotoTests.swift; sourceTree = "<group>"; };
 		A41D866E2B73D47400F24064 /* PipeableElement_ClickTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipeableElement_ClickTests.swift; sourceTree = "<group>"; };
@@ -135,6 +137,7 @@
 				E8F7B28C2B639E160040B77B /* ScriptTests.swift */,
 				A40EAC682B6BC88B00A6B6B3 /* PipeableXCTestCase.swift */,
 				A40EAC6B2B6BD0A100A6B6B3 /* PipeablePage_GotoTests.swift */,
+				A40BE09A2B84B59F00906441 /* PipeablePage_WaitForURLTests.swift */,
 				A41D866E2B73D47400F24064 /* PipeableElement_ClickTests.swift */,
 				E81BD5B32B6D4963007DFC02 /* PageScript_GotoTests.swift */,
 				A49B0A802B725F86005C1105 /* PageScript_QuerySelectorTests.swift */,
@@ -343,6 +346,7 @@
 				A49B0A812B725F86005C1105 /* PageScript_QuerySelectorTests.swift in Sources */,
 				A41D866F2B73D47400F24064 /* PipeableElement_ClickTests.swift in Sources */,
 				A40EAC6C2B6BD0A100A6B6B3 /* PipeablePage_GotoTests.swift in Sources */,
+				A40BE09B2B84B59F00906441 /* PipeablePage_WaitForURLTests.swift in Sources */,
 				A40BE0992B83946800906441 /* PageLoadStateTests.swift in Sources */,
 				E8F7B28E2B639E160040B77B /* ScriptTests.swift in Sources */,
 				E81BD5B42B6D4963007DFC02 /* PageScript_GotoTests.swift in Sources */,

--- a/PipeableTests/PipeablePage_GotoTests.swift
+++ b/PipeableTests/PipeablePage_GotoTests.swift
@@ -103,4 +103,25 @@ final class PipeablePageGotoTests: PipeableXCTestCase {
             }
         }
     }
+
+    func testWaitForURLBadServer() async throws {
+        let page = PipeablePage(webView)
+
+        do {
+            try await page.goto(
+                "http://localhost:3001/load_latency/0/index.html",
+                waitUntil: .load
+            )
+        } catch {
+            if let error = error as? PipeableError {
+                if case PipeableError.navigationError(_) = error {
+                    return
+                } else {
+                    XCTFail("Unexpected error \(error)")
+                }
+            }
+        }
+
+        XCTFail("Should have thrown a PipeableError")
+    }
 }

--- a/PipeableTests/PipeablePage_WaitForURLTests.swift
+++ b/PipeableTests/PipeablePage_WaitForURLTests.swift
@@ -1,0 +1,76 @@
+@testable import PipeableSDK
+import WebKit
+import XCTest
+
+final class PipeablePageWaitForURLTests: PipeableXCTestCase {
+    func testGotoWithAboutBlankAndWaitForURL() async throws {
+        let page = PipeablePage(webView)
+
+        try? await page.goto("about:blank")
+
+        try await page.waitForURL { url in url == "about:blank" }
+
+        let url = await page.url()
+        XCTAssertEqual(url?.absoluteString, "about:blank")
+    }
+
+    func testWaitForURLSuccess() async throws {
+        let page = PipeablePage(webView)
+
+        try await page.goto(
+            "\(testServerURL)/load_latency/3000/index.html",
+            waitUntil: .domcontentloaded
+        )
+
+        guard let linkEl = try await page.waitForSelector("a#link_to_another") else {
+            XCTFail("Could not find the link element")
+            return
+        }
+
+        try await linkEl.click()
+
+        let waitForPredicate = { url in
+            url == "\(testServerURL)/load_latency/3000/another.html"
+        }
+
+        try await page.waitForURL(waitForPredicate, waitUntil: .domcontentloaded, timeout: 1000)
+
+        let h1El = try await page.waitForSelector("h1")
+        let text = try await h1El?.textContent()
+        XCTAssertEqual(text, "Hello from another!")
+    }
+
+    func testWaitForURLWithTimeout() async throws {
+        let page = PipeablePage(webView)
+
+        try await page.goto(
+            "\(testServerURL)/load_latency/2000/index.html",
+            waitUntil: .domcontentloaded
+        )
+
+        guard let linkEl = try await page.waitForSelector("a#link_to_another") else {
+            XCTFail("Could not find the link element")
+            return
+        }
+
+        try await linkEl.click()
+
+        let waitForPredicate = { url in
+            url == "\(testServerURL)/load_latency/2000/another.html"
+        }
+
+        do {
+            try await page.waitForURL(waitForPredicate, waitUntil: .load, timeout: 500)
+        } catch {
+            if let error = error as? PipeableError {
+                if case .navigationError = error {
+                    return
+                }
+            }
+
+            XCTFail("Unexpected error \(error)")
+        }
+
+        XCTFail("Should have timed out")
+    }
+}

--- a/Sources/PipeableSDK/PageLoadState.swift
+++ b/Sources/PipeableSDK/PageLoadState.swift
@@ -40,8 +40,6 @@ class PageLoadState {
     }
 
     func waitForLoadStateChange(predicate: @escaping (_ state: LoadState, _ url: String?) -> Bool, timeout: Int) async throws {
-        // Otherwise, wait until we get there or we time out.
-
         // Since there is a potential race condition that can lead to double
         // "resume" calls on the continuation, we need to ensure that the
         // continuation is only resumed once. We guard this by running resumes

--- a/Sources/PipeableSDK/PipeablePage.swift
+++ b/Sources/PipeableSDK/PipeablePage.swift
@@ -23,7 +23,7 @@ public class PipeablePage {
         private var loadPageState: PageLoadState
 
         init(_ loadPageSignal: PageLoadState) {
-            self.loadPageState = loadPageSignal
+            loadPageState = loadPageSignal
         }
 
         func webView(_: WKWebView, didFinish _: WKNavigation) {
@@ -239,95 +239,37 @@ public class PipeablePage {
             return
         }
 
-        // Otherwise, wait until we get there or we time out.
-
-        // Since there is a potential race condition that can lead to double
-        // "resume" calls on the continuation, we need to ensure that the
-        // continuation is only resumed once. We guard this by running resumes
-        // in a queue and using a helper.
-        class ResumeOnce {
-            let queueForResuming = DispatchQueue(label: "waitForLoadState")
-            var isResumed = false
-
-            func resume(action: () -> Void) {
-                queueForResuming.sync {
-                    if !isResumed {
-                        isResumed = true
-                        action()
-                    }
-                }
-            }
-        }
-
-        let resumeOnce = ResumeOnce()
-
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            var timeoutTask: Task<Void, Never>?
-
-            let removeListener = self.pageLoadState.subscribeToLoadStateChange { state, _, error in
-                if let error = error {
-                    resumeOnce.resume {
-                        continuation.resume(throwing: error)
-                    }
-
-                    // Clean up timer.
-                    timeoutTask?.cancel()
-
-                    return true
-                } else if state.rawValue >= LoadState.fromWaitUntil(waitUntil).rawValue {
-                    resumeOnce.resume {
-                        continuation.resume(returning: ())
-                    }
-
-                    // Clean up timer.
-                    timeoutTask?.cancel()
-                    return true
-                }
-
-                return false
-            }
-
-            timeoutTask = Task {
-                do {
-                    try await Task.sleep(nanoseconds: UInt64(timeout) * 1000000)
-                } catch {
-                    // If the sleep is cancelled, then we move to
-                }
-                removeListener()
-
-                resumeOnce.resume {
-                    continuation.resume(throwing: PipeableError.navigationError("The request timed out."))
-                }
-            }
-        }
+        try await pageLoadState.waitForLoadStateChange(
+            predicate: { state, _ in
+                state.rawValue >= LoadState.fromWaitUntil(waitUntil).rawValue
+            },
+            timeout: timeout
+        )
     }
 
     // TODO: Implement timeout
     // TODO: Implement shorthards for predicates -- string matching, regex matching
-    public func waitForURL(_ predicate: @escaping (String) -> Bool, waitUntil: WaitUntilOption = .load) async throws {
+    public func waitForURL(
+        _ predicate: @escaping (String) -> Bool,
+        waitUntil: WaitUntilOption = .load,
+        timeout: Int = 30000
+    ) async throws {
         if let currentUrl = await url()?.absoluteString {
-            if predicate(currentUrl) {
+            if predicate(currentUrl), pageLoadState.state.rawValue >= LoadState.fromWaitUntil(waitUntil).rawValue {
                 return
             }
         }
 
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            _ = self.pageLoadState.subscribeToLoadStateChange { state, url, error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                    return true
-                } else if
-                    let url = url,
-                    state.rawValue >= LoadState.fromWaitUntil(waitUntil).rawValue,
-                    predicate(url)
-                {
-                    continuation.resume(returning: ())
-                    return true
+        try await pageLoadState.waitForLoadStateChange(
+            predicate: { state, url in
+                if let url = url {
+                    return state.rawValue >= LoadState.fromWaitUntil(waitUntil).rawValue && predicate(url)
+                } else {
+                    return false
                 }
-
-                return false
-            }
-        }
+            },
+            timeout: timeout
+        )
     }
 
     public func querySelector(_ selector: String) async throws -> PipeableElement? {

--- a/Sources/PipeableSDK/PipeablePage.swift
+++ b/Sources/PipeableSDK/PipeablePage.swift
@@ -33,7 +33,7 @@ public class PipeablePage {
         }
 
         func webView(_ webView: WKWebView, didStartProvisionalNavigation _: WKNavigation) {
-            loadPageState.changeState(state: .notloaded, url: webView.url?.absoluteString)
+            loadPageState.changeState(state: .notloaded, url: nil)
         }
 
         func webView(_ webView: WKWebView, didFail _: WKNavigation, withError error: Error) {
@@ -254,12 +254,6 @@ public class PipeablePage {
         waitUntil: WaitUntilOption = .load,
         timeout: Int = 30000
     ) async throws {
-        if let currentUrl = await url()?.absoluteString {
-            if predicate(currentUrl), pageLoadState.state.rawValue >= LoadState.fromWaitUntil(waitUntil).rawValue {
-                return
-            }
-        }
-
         try await pageLoadState.waitForLoadStateChange(
             predicate: { state, url in
                 if let url = url {

--- a/TestServer/public/load_latency/another.html
+++ b/TestServer/public/load_latency/another.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Click Test Cases</title>
+    <title>Another</title>
     <script type="text/javascript">
       window.addEventListener("DOMContentLoaded", function () {
         console.log("domcontentloaded");
@@ -21,7 +21,7 @@
   </head>
   <body>
     <div id="container">
-      <h1>Hello!</h1>
+      <h1>Hello from another!</h1>
       <a id="link_to_another" href="another.html">Another Page</a>
     </div>
   </body>

--- a/TestServer/server.mjs
+++ b/TestServer/server.mjs
@@ -22,7 +22,7 @@ app.get('/goto/timeout/:ms', (req, res) => {
 // This way domcontentloaded is fast, but the load event is slowed down.
 
 // Dynamic route to set latency and serve the requested file
-app.get('/load_latency/:ms/index.html', (req, res) => {
+app.get('/load_latency/:ms/*.html', (req, res) => {
     // Set script latency based on URL parameter
     const delay = parseInt(req.params.ms, 10);
     if (isNaN(delay)) {
@@ -30,8 +30,9 @@ app.get('/load_latency/:ms/index.html', (req, res) => {
         return;
     }
 
+    const fileName = req.params[0];
     // Serve the file from the public directory
-    const fullPath = path.resolve(path.join('public', 'load_latency', 'index.html'));
+    const fullPath = path.resolve(path.join('public', 'load_latency', fileName + '.html'));
     const fileContents = fs.readFileSync(fullPath, 'utf8');
     const modifiedContents = fileContents.replace('{{delay}}', delay.toString());
     res.contentType('text/html').send(modifiedContents);


### PR DESCRIPTION
- Added `waitForLoadStateChange` in PageLoadState which is async / await based in addition to the `subscribeToLoadChange` callback-based
- Use it for `page.waitForLoadState`, `page.goto(waitUntil)` and `page.waitForURL()`

- While developing figured out that the code breaks if you visit an inaccessible URL. Added a test in the goto section for visiting bad urls.