### PR TITLE
PipeablePage.goto() returns HTTPStatus

### DIFF
--- a/PipeableSDK.xcodeproj/project.pbxproj
+++ b/PipeableSDK.xcodeproj/project.pbxproj
@@ -14,13 +14,14 @@
 		A40EAC6C2B6BD0A100A6B6B3 /* PipeablePage_GotoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40EAC6B2B6BD0A100A6B6B3 /* PipeablePage_GotoTests.swift */; };
 		A41D866F2B73D47400F24064 /* PipeableElement_ClickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A41D866E2B73D47400F24064 /* PipeableElement_ClickTests.swift */; };
 		A434C6162B5964B300B8011C /* PipeablePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A434C6152B5964B300B8011C /* PipeablePage.swift */; };
+		A43DC2952B8CD780005E416D /* ScriptContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43DC2942B8CD780005E416D /* ScriptContext.swift */; };
 		A43DC58A2B7277C100D0670B /* PipeableElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43DC5892B7277C100D0670B /* PipeableElement.swift */; };
 		A49B0A812B725F86005C1105 /* PageScript_QuerySelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A49B0A802B725F86005C1105 /* PageScript_QuerySelectorTests.swift */; };
 		A4A7A9262B56BD7500982E63 /* Pipeable.docc in Sources */ = {isa = PBXBuildFile; fileRef = A4A7A9252B56BD7500982E63 /* Pipeable.docc */; };
 		A4A7A9312B56BD7500982E63 /* PipeableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4A7A9302B56BD7500982E63 /* PipeableTests.swift */; };
 		A4A7A9322B56BD7500982E63 /* Pipeable.h in Headers */ = {isa = PBXBuildFile; fileRef = A4A7A9242B56BD7500982E63 /* Pipeable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A4C365FC2B62A3C5000D3F50 /* sophia.js in Resources */ = {isa = PBXBuildFile; fileRef = A4C365FB2B62A3C5000D3F50 /* sophia.js */; };
-		E80933752B83B0FA0024965E /* ScriptContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80933742B83B0FA0024965E /* ScriptContext.swift */; };
+		A4DF83B52B8CD0B3000EFCEA /* PipeablePageDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4DF83B42B8CD0B3000EFCEA /* PipeablePageDelegate.swift */; };
 		E81BD5AA2B6D4233007DFC02 /* BaseWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81BD5A92B6D4233007DFC02 /* BaseWrapper.swift */; };
 		E81BD5AE2B6D430A007DFC02 /* PageWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81BD5AD2B6D430A007DFC02 /* PageWrapper.swift */; };
 		E81BD5B02B6D45B6007DFC02 /* ElementWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81BD5AF2B6D45B6007DFC02 /* ElementWrapper.swift */; };
@@ -48,6 +49,7 @@
 		A40EAC6B2B6BD0A100A6B6B3 /* PipeablePage_GotoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipeablePage_GotoTests.swift; sourceTree = "<group>"; };
 		A41D866E2B73D47400F24064 /* PipeableElement_ClickTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipeableElement_ClickTests.swift; sourceTree = "<group>"; };
 		A434C6152B5964B300B8011C /* PipeablePage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipeablePage.swift; sourceTree = "<group>"; };
+		A43DC2942B8CD780005E416D /* ScriptContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScriptContext.swift; sourceTree = "<group>"; };
 		A43DC5892B7277C100D0670B /* PipeableElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PipeableElement.swift; sourceTree = "<group>"; };
 		A450D1BB2B59750800079EAF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A49B0A802B725F86005C1105 /* PageScript_QuerySelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageScript_QuerySelectorTests.swift; sourceTree = "<group>"; };
@@ -57,7 +59,7 @@
 		A4A7A92B2B56BD7500982E63 /* PipeableSDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PipeableSDKTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A4A7A9302B56BD7500982E63 /* PipeableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipeableTests.swift; sourceTree = "<group>"; };
 		A4C365FB2B62A3C5000D3F50 /* sophia.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = sophia.js; sourceTree = "<group>"; };
-		E80933742B83B0FA0024965E /* ScriptContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScriptContext.swift; sourceTree = "<group>"; };
+		A4DF83B42B8CD0B3000EFCEA /* PipeablePageDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipeablePageDelegate.swift; sourceTree = "<group>"; };
 		E81BD5A92B6D4233007DFC02 /* BaseWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseWrapper.swift; sourceTree = "<group>"; };
 		E81BD5AD2B6D430A007DFC02 /* PageWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageWrapper.swift; sourceTree = "<group>"; };
 		E81BD5AF2B6D45B6007DFC02 /* ElementWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementWrapper.swift; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 				A434C6152B5964B300B8011C /* PipeablePage.swift */,
 				E8AC39A12B615BC900D413BF /* Script */,
 				A40BE0952B8393A800906441 /* PageLoadState.swift */,
+				A4DF83B42B8CD0B3000EFCEA /* PipeablePageDelegate.swift */,
 			);
 			path = PipeableSDK;
 			sourceTree = "<group>";
@@ -161,8 +164,8 @@
 		E8AC39A12B615BC900D413BF /* Script */ = {
 			isa = PBXGroup;
 			children = (
-				E80933742B83B0FA0024965E /* ScriptContext.swift */,
 				E8AC39A42B615C1D00D413BF /* Script.swift */,
+				A43DC2942B8CD780005E416D /* ScriptContext.swift */,
 				E81BD5A92B6D4233007DFC02 /* BaseWrapper.swift */,
 				E81BD5AD2B6D430A007DFC02 /* PageWrapper.swift */,
 				E81BD5AF2B6D45B6007DFC02 /* ElementWrapper.swift */,
@@ -327,13 +330,14 @@
 			files = (
 				A43DC58A2B7277C100D0670B /* PipeableElement.swift in Sources */,
 				E81BD5B62B6D5092007DFC02 /* Fakes.swift in Sources */,
+				A4DF83B52B8CD0B3000EFCEA /* PipeablePageDelegate.swift in Sources */,
 				E81BD5AA2B6D4233007DFC02 /* BaseWrapper.swift in Sources */,
+				A43DC2952B8CD780005E416D /* ScriptContext.swift in Sources */,
 				A4A7A9262B56BD7500982E63 /* Pipeable.docc in Sources */,
 				E8AC39A52B615C1D00D413BF /* Script.swift in Sources */,
 				A40BE0962B8393A800906441 /* PageLoadState.swift in Sources */,
 				E81BD5AE2B6D430A007DFC02 /* PageWrapper.swift in Sources */,
 				E81BD5B02B6D45B6007DFC02 /* ElementWrapper.swift in Sources */,
-				E80933752B83B0FA0024965E /* ScriptContext.swift in Sources */,
 				A434C6162B5964B300B8011C /* PipeablePage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PipeableTests/PipeableElement_ClickTests.swift
+++ b/PipeableTests/PipeableElement_ClickTests.swift
@@ -26,7 +26,7 @@ final class PipeableElementClickTests: PipeableXCTestCase {
 
     func testClickOnInvisibleElementsShouldFail() async throws {
         let page = PipeablePage(webView)
-        try? await page.goto("\(testServerURL)/click.html")
+        _ = try? await page.goto("\(testServerURL)/click.html")
         let invisibleLinkEl = try await page.querySelector("#invisible_link")
 
         do {
@@ -47,7 +47,7 @@ final class PipeableElementClickTests: PipeableXCTestCase {
     private func registerClick(action: @escaping (_ page: PipeablePage) async throws -> Void) async throws {
         let page = PipeablePage(webView)
 
-        try? await page.goto("\(testServerURL)/click.html")
+        _ = try? await page.goto("\(testServerURL)/click.html")
 
         let clicksBefore = try await page.evaluate("window.clicks")
         guard let numClicksBefore = clicksBefore as? Int else {

--- a/PipeableTests/PipeablePage_WaitForURLTests.swift
+++ b/PipeableTests/PipeablePage_WaitForURLTests.swift
@@ -6,7 +6,7 @@ final class PipeablePageWaitForURLTests: PipeableXCTestCase {
     func testGotoWithAboutBlankAndWaitForURL() async throws {
         let page = PipeablePage(webView)
 
-        try? await page.goto("about:blank")
+        _ = try? await page.goto("about:blank")
 
         try await page.waitForURL { url in url == "about:blank" }
 
@@ -17,7 +17,7 @@ final class PipeablePageWaitForURLTests: PipeableXCTestCase {
     func testWaitForURLSuccess() async throws {
         let page = PipeablePage(webView)
 
-        try await page.goto(
+        _ = try await page.goto(
             "\(testServerURL)/load_latency/3000/index.html",
             waitUntil: .domcontentloaded
         )
@@ -43,7 +43,7 @@ final class PipeablePageWaitForURLTests: PipeableXCTestCase {
     func testWaitForURLWithTimeout() async throws {
         let page = PipeablePage(webView)
 
-        try await page.goto(
+        _ = try await page.goto(
             "\(testServerURL)/load_latency/2000/index.html",
             waitUntil: .domcontentloaded
         )

--- a/Sources/PipeableSDK/PipeablePageDelegate.swift
+++ b/Sources/PipeableSDK/PipeablePageDelegate.swift
@@ -1,0 +1,78 @@
+import Foundation
+import WebKit
+
+class PipeablePageDelegate: NSObject, WKNavigationDelegate {
+    private var loadPageState: PageLoadState
+    private var lastHTTPResponse: PipeablePage.LastHTTPResponse
+
+    init(_ loadPageSignal: PageLoadState, _ lastHTTPResponse: PipeablePage.LastHTTPResponse) {
+        loadPageState = loadPageSignal
+        self.lastHTTPResponse = lastHTTPResponse
+    }
+
+    func webView(_: WKWebView, didFinish _: WKNavigation) {
+        // Used to fire the DOMContentloaded here, but it actually is not really domcontentloaded, more like .load
+        // Right now everything is fired from JS, but we might want to fire load here as well, just in case
+        // some script deregisters all listeners on boot.
+    }
+
+    func webView(_: WKWebView, didStartProvisionalNavigation _: WKNavigation) {
+        loadPageState.changeState(state: .notloaded, url: nil)
+        Task { await lastHTTPResponse.setLastHTTPResponse(nil) }
+    }
+
+    func webView(_ webView: WKWebView, didFail _: WKNavigation, withError error: Error) {
+        loadPageState.error(
+            error: PipeableError.navigationError(error.localizedDescription),
+            url: webView.url?.absoluteString
+        )
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation _: WKNavigation, withError error: Error) {
+        loadPageState.error(
+            error: PipeableError.navigationError(error.localizedDescription),
+            url: webView.url?.absoluteString
+        )
+    }
+
+    func webView(_: WKWebView, didReceive _: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        completionHandler(.performDefaultHandling, nil)
+    }
+
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        loadPageState.error(error: PipeableError.navigationError("Terminated"), url: webView.url?.absoluteString)
+    }
+
+    func webView(_: WKWebView, decidePolicyFor _: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        decisionHandler(.allow)
+    }
+
+    func webView(
+        _: WKWebView,
+        decidePolicyFor navigationResponse: WKNavigationResponse,
+        decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
+    ) {
+        if let httpResponse = navigationResponse.response as? HTTPURLResponse {
+            if navigationResponse.isForMainFrame {
+                // Collecting all headers
+                let allHeaders = httpResponse.allHeaderFields
+                // Casting to [String: String] if necessary. Note: Some header field values might not be String.
+                let headersDictionary: [String: String] =
+                    allHeaders.reduce(into: [String: String]()) { result, pair in
+                        if let key = pair.key as? String, let value = pair.value as? String {
+                            result[key] = value
+                        }
+                    }
+
+                let httpResponse = PipeableHTTPResponse(
+                    status: httpResponse.statusCode,
+                    headers: headersDictionary
+                )
+
+                Task { await lastHTTPResponse.setLastHTTPResponse(httpResponse) }
+            }
+        }
+
+        decisionHandler(.allow)
+    }
+}

--- a/Sources/PipeableSDK/Script/PageWrapper.swift
+++ b/Sources/PipeableSDK/Script/PageWrapper.swift
@@ -26,7 +26,7 @@ final class PageWrapper: BaseWrapper, PageJSExport {
                 throw PipeableError.invalidParameter("Invalid waitUntil option passed: \(waitUntilRaw)")
             }
 
-            try await self.page.goto(url, waitUntil: waitUntil, timeout: timeout)
+            _ = try await self.page.goto(url, waitUntil: waitUntil, timeout: timeout)
             return CompletionResult.success(nil)
         }
     }

--- a/TestServer/server.mjs
+++ b/TestServer/server.mjs
@@ -52,6 +52,13 @@ app.use('/load_latency/assets/', (req, __, next) => {
     }, delay);
 });
 
+// Test that we can read special headers set on responses.
+app.get('/header_test', (_, res) => {
+    res.set('X-Test-Header', 'Test');
+
+    res.send('<html><body>Test</body></html>');
+});
+
 // Serve static files from the "public" directory
 app.use(express.static('public'));
 


### PR DESCRIPTION
`PipeablePage.goto` now returns `PipeableHTTPStatus`, which contains the http status and the response headers.

It is captured in the Delegate and set on the PipeablePage instance. In the end decided not to bundle it with LoadPageStatus, since they have different purposes -- one tracks the load status and the other one records the http response to be returned in `goto` or in `waitForURL`.

One downside to this, actually, is that we'll be retaining the last HTTP response for the duration of the entire page, while we won't need it after the `goto` result.

Refactored the Delegate out into its own file.