### PR TITLE
Add more debug info to script errors

### DIFF
--- a/PipeableTests/PageScript_GotoTests.swift
+++ b/PipeableTests/PageScript_GotoTests.swift
@@ -53,7 +53,7 @@ final class PageScriptGotoTests: PipeableXCTestCase {
             XCTFail("Expected an error, but no error was thrown.")
         } catch {
             // Check if the caught error is of type PipeableError.navigationError ("The request timed out.")
-            if case let ScriptError.error(reason) = error {
+            if case let ScriptError.error(reason, _) = error {
                 if reason.contains("timed out") {
                     return
                 }

--- a/PipeableTests/PageScript_QuerySelectorTests.swift
+++ b/PipeableTests/PageScript_QuerySelectorTests.swift
@@ -34,7 +34,7 @@ final class PageScriptQuerySelectorTests: PipeableXCTestCase {
                 """, page)
 
             XCTFail("Should fail with SyntaxError")
-        } catch let ScriptError.error(reason) {
+        } catch let ScriptError.error(reason, _) {
             XCTAssert(reason.contains("SyntaxError"), "Did not receive SyntaxError: \(reason)")
         } catch {
             XCTFail("Unexpected error \(error)")

--- a/Sources/PipeableSDK/Script/BaseWrapper.swift
+++ b/Sources/PipeableSDK/Script/BaseWrapper.swift
@@ -34,9 +34,9 @@ class BaseWrapper: NSObject {
                     }
                 }
             } catch let PipeableError.navigationError(errorMessage) {
-                completionHandler.call(withArguments: [["error": "Navigation error: \(errorMessage)"]])
+                completionHandler.call(withArguments: [["error": "NavigationError: \(errorMessage)"]])
             } catch PipeableError.elementNotFound {
-                completionHandler.call(withArguments: [["error": "Element not found."]])
+                completionHandler.call(withArguments: [["error": "PipeableError: Element not found."]])
             } catch {
                 completionHandler.call(withArguments: [["error": "Unexpected error \(error)"]])
             }

--- a/Sources/PipeableSDK/Script/Script.swift
+++ b/Sources/PipeableSDK/Script/Script.swift
@@ -16,13 +16,17 @@ public func prepareJSContext(_ dispatchGroup: DispatchGroup, _ page: PipeablePag
     // Set exception handler
     context.exceptionHandler = { _, exception in
         if let exception = exception {
-            // Print the exception, set it as the error of the script, so it's passed to "runScript".
-            var errorMessage = exception.description
+            if let exceptionDictionary = exception.toDictionary() {
+                if let line = exceptionDictionary["line"] as? NSNumber {
+                    context.evaluateScript("__errorLine = \(line)")
+                }
+            }
             if let exceptionObject = exception.toObject() {
-                errorMessage = "\(errorMessage)\n\(exceptionObject)"
+                context.evaluateScript("__errorRawObject = `\(exceptionObject)`")
             }
 
-            let script = "__error = `" + errorMessage + "`"
+            // Print the exception, set it as the error of the script, so it's passed to "runScript".
+            let script = "__error = `\(exception.description)`"
             context.evaluateScript(script)
         }
     }
@@ -105,40 +109,88 @@ public func prepareJSContext(_ dispatchGroup: DispatchGroup, _ page: PipeablePag
     return context
 }
 
+public struct ScriptErrorInfo {
+    let stack: String?
+    let line: Int?
+    let column: Int?
+
+    // The raw stringified Error object returned from the JS script. Used for debugging purposes.
+    let rawObject: String?
+}
+
 public enum ScriptError: Error {
-    case error(reason: String)
+    case error(reason: String, info: ScriptErrorInfo)
     case unexpectedError
+}
+
+// The offset when reporting error lines calculated based on the main script below.
+private let mainScriptLineOffset = 2
+private func buildMainScript(_ script: String) -> String {
+    return """
+    async function asyncCallWithError() {
+        __context.scriptStarted();
+        \(script)
+    }
+
+    // Put as much as possible code after asyncCallWithError so that
+    // there are less changes to the script line offset.
+
+    var __error = undefined;
+    var __errorStack = undefined;
+    var __errorLine = undefined;
+    var __errorColumn = undefined;
+    var __errorRawObject = undefined;
+    var __result = undefined;
+
+    asyncCallWithError().then(
+        (result) => {
+            __result = result;
+            __context.scriptEnded();
+        },
+        (e) => {
+            __error = e.toString();
+
+            if(e.stack) {
+                __errorStack = e.stack;
+            }
+
+            if(e.line) {
+                __errorLine = e.line;
+            }
+
+            if(e.column) {
+                __errorColumn = e.column;
+            }
+
+            if(e instanceof Error) {
+                __errorRawObject = JSON.stringify(e, Object.getOwnPropertyNames(e));
+            }
+
+            __context.scriptEnded();
+        }
+    );
+    """
 }
 
 public func runScript(_ script: String, _ page: PipeablePage? = nil) async throws -> JSValue {
     return try await withCheckedThrowingContinuation { continuation in
+        // Use a DispatchGroup so that we wait for the script and all async functions to finish before returning
         let dispatchGroup = DispatchGroup()
         let context = prepareJSContext(dispatchGroup, page)
 
-        context.evaluateScript("""
-        var __error = undefined;
-        var __result = undefined;
-        async function asyncCallWithError() {
-            __context.scriptStarted()
-            \(script)
-        }
-        asyncCallWithError().then(
-            (result) => {
-                __result = result;
-                __context.scriptEnded()
-            },
-            (e) => {
-                __error = e.toString();
-                __context.scriptEnded()
-            }
-        );
-        """)
+        context.evaluateScript(buildMainScript(script))
 
         dispatchGroup.notify(queue: .main) {
             if let error = context.objectForKeyedSubscript("__error") {
                 if !error.isUndefined {
-                    // TODO: Figure out how to convert back to PipeableErrors the PipeableError's, so that ScriptError is just a JS error.
-                    continuation.resume(throwing: ScriptError.error(reason: error.toString()))
+                    let stack = getStringFromJSValue(context.objectForKeyedSubscript("__errorStack"))
+                    let line = getLineFromJSValue(context.objectForKeyedSubscript("__errorLine"))
+                    let column = getIntFromJSValue(context.objectForKeyedSubscript("__errorColumn"))
+                    let rawObject = getStringFromJSValue(context.objectForKeyedSubscript("__errorRawObject"))
+
+                    continuation.resume(throwing: ScriptError.error(
+                        reason: error.toString(),
+                        info: ScriptErrorInfo(stack: stack, line: line, column: column, rawObject: rawObject)))
                     return
                 }
             }
@@ -151,4 +203,25 @@ public func runScript(_ script: String, _ page: PipeablePage? = nil) async throw
             continuation.resume(throwing: ScriptError.unexpectedError)
         }
     }
+}
+
+private func getStringFromJSValue(_ jsValue: JSValue) -> String? {
+    if jsValue.isString {
+        return jsValue.toString()
+    }
+    return nil
+}
+
+private func getIntFromJSValue(_ jsValue: JSValue) -> Int? {
+    if jsValue.isNumber {
+        return jsValue.toNumber().intValue
+    }
+    return nil
+}
+
+private func getLineFromJSValue(_ jsValue: JSValue) -> Int? {
+    if let line = getIntFromJSValue(jsValue) {
+        return line - mainScriptLineOffset
+    }
+    return nil
 }


### PR DESCRIPTION
Expose line, column and stack (not very useful...) from script errors.
Fix line position of errors by using an offset.
Did not find a way for async functions to output meaningful debug info as their implementation is defined in another call to `evaluateScript` and Errors get the `line` and `column` from the script in which they are created... :( Leaving it as it is for now.