### PR TITLE
Add a way to serialize a Swift object to JSValue object

### DIFF
--- a/PipeableSDK.xcodeproj/project.pbxproj
+++ b/PipeableSDK.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		E81BD5B42B6D4963007DFC02 /* PageScript_GotoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81BD5B32B6D4963007DFC02 /* PageScript_GotoTests.swift */; };
 		E81BD5B62B6D5092007DFC02 /* Fakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81BD5B52B6D5092007DFC02 /* Fakes.swift */; };
 		E8AC39A52B615C1D00D413BF /* Script.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8AC39A42B615C1D00D413BF /* Script.swift */; };
+		E8C2784F2B8E0D9100B8B176 /* SerializeToDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C2784E2B8E0D9100B8B176 /* SerializeToDictionary.swift */; };
 		E8F7B28E2B639E160040B77B /* ScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F7B28C2B639E160040B77B /* ScriptTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -66,6 +67,7 @@
 		E81BD5B32B6D4963007DFC02 /* PageScript_GotoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageScript_GotoTests.swift; sourceTree = "<group>"; };
 		E81BD5B52B6D5092007DFC02 /* Fakes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fakes.swift; sourceTree = "<group>"; };
 		E8AC39A42B615C1D00D413BF /* Script.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Script.swift; sourceTree = "<group>"; };
+		E8C2784E2B8E0D9100B8B176 /* SerializeToDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerializeToDictionary.swift; sourceTree = "<group>"; };
 		E8F7B28C2B639E160040B77B /* ScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -170,6 +172,7 @@
 				E81BD5AD2B6D430A007DFC02 /* PageWrapper.swift */,
 				E81BD5AF2B6D45B6007DFC02 /* ElementWrapper.swift */,
 				E81BD5B52B6D5092007DFC02 /* Fakes.swift */,
+				E8C2784E2B8E0D9100B8B176 /* SerializeToDictionary.swift */,
 			);
 			path = Script;
 			sourceTree = "<group>";
@@ -339,6 +342,7 @@
 				E81BD5AE2B6D430A007DFC02 /* PageWrapper.swift in Sources */,
 				E81BD5B02B6D45B6007DFC02 /* ElementWrapper.swift in Sources */,
 				A434C6162B5964B300B8011C /* PipeablePage.swift in Sources */,
+				E8C2784F2B8E0D9100B8B176 /* SerializeToDictionary.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PipeableSDK.xcodeproj/project.pbxproj
+++ b/PipeableSDK.xcodeproj/project.pbxproj
@@ -27,8 +27,9 @@
 		E81BD5B02B6D45B6007DFC02 /* ElementWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81BD5AF2B6D45B6007DFC02 /* ElementWrapper.swift */; };
 		E81BD5B42B6D4963007DFC02 /* PageScript_GotoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81BD5B32B6D4963007DFC02 /* PageScript_GotoTests.swift */; };
 		E81BD5B62B6D5092007DFC02 /* Fakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81BD5B52B6D5092007DFC02 /* Fakes.swift */; };
+		E82CD6912B8F0AE400416B90 /* ScriptSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E82CD6902B8F0AE400416B90 /* ScriptSerializerTests.swift */; };
 		E8AC39A52B615C1D00D413BF /* Script.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8AC39A42B615C1D00D413BF /* Script.swift */; };
-		E8C2784F2B8E0D9100B8B176 /* SerializeToDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C2784E2B8E0D9100B8B176 /* SerializeToDictionary.swift */; };
+		E8C2784F2B8E0D9100B8B176 /* Serializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C2784E2B8E0D9100B8B176 /* Serializer.swift */; };
 		E8F7B28E2B639E160040B77B /* ScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F7B28C2B639E160040B77B /* ScriptTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -66,8 +67,9 @@
 		E81BD5AF2B6D45B6007DFC02 /* ElementWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementWrapper.swift; sourceTree = "<group>"; };
 		E81BD5B32B6D4963007DFC02 /* PageScript_GotoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageScript_GotoTests.swift; sourceTree = "<group>"; };
 		E81BD5B52B6D5092007DFC02 /* Fakes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fakes.swift; sourceTree = "<group>"; };
+		E82CD6902B8F0AE400416B90 /* ScriptSerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptSerializerTests.swift; sourceTree = "<group>"; };
 		E8AC39A42B615C1D00D413BF /* Script.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Script.swift; sourceTree = "<group>"; };
-		E8C2784E2B8E0D9100B8B176 /* SerializeToDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerializeToDictionary.swift; sourceTree = "<group>"; };
+		E8C2784E2B8E0D9100B8B176 /* Serializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Serializer.swift; sourceTree = "<group>"; };
 		E8F7B28C2B639E160040B77B /* ScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -145,6 +147,7 @@
 				A41D866E2B73D47400F24064 /* PipeableElement_ClickTests.swift */,
 				E81BD5B32B6D4963007DFC02 /* PageScript_GotoTests.swift */,
 				A49B0A802B725F86005C1105 /* PageScript_QuerySelectorTests.swift */,
+				E82CD6902B8F0AE400416B90 /* ScriptSerializerTests.swift */,
 			);
 			path = PipeableTests;
 			sourceTree = "<group>";
@@ -172,7 +175,7 @@
 				E81BD5AD2B6D430A007DFC02 /* PageWrapper.swift */,
 				E81BD5AF2B6D45B6007DFC02 /* ElementWrapper.swift */,
 				E81BD5B52B6D5092007DFC02 /* Fakes.swift */,
-				E8C2784E2B8E0D9100B8B176 /* SerializeToDictionary.swift */,
+				E8C2784E2B8E0D9100B8B176 /* Serializer.swift */,
 			);
 			path = Script;
 			sourceTree = "<group>";
@@ -342,7 +345,7 @@
 				E81BD5AE2B6D430A007DFC02 /* PageWrapper.swift in Sources */,
 				E81BD5B02B6D45B6007DFC02 /* ElementWrapper.swift in Sources */,
 				A434C6162B5964B300B8011C /* PipeablePage.swift in Sources */,
-				E8C2784F2B8E0D9100B8B176 /* SerializeToDictionary.swift in Sources */,
+				E8C2784F2B8E0D9100B8B176 /* Serializer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -352,6 +355,7 @@
 			files = (
 				A40EAC692B6BC88B00A6B6B3 /* PipeableXCTestCase.swift in Sources */,
 				A49B0A812B725F86005C1105 /* PageScript_QuerySelectorTests.swift in Sources */,
+				E82CD6912B8F0AE400416B90 /* ScriptSerializerTests.swift in Sources */,
 				A41D866F2B73D47400F24064 /* PipeableElement_ClickTests.swift in Sources */,
 				A40EAC6C2B6BD0A100A6B6B3 /* PipeablePage_GotoTests.swift in Sources */,
 				A40BE09B2B84B59F00906441 /* PipeablePage_WaitForURLTests.swift in Sources */,

--- a/PipeableTests/PageScript_GotoTests.swift
+++ b/PipeableTests/PageScript_GotoTests.swift
@@ -73,4 +73,26 @@ final class PageScriptGotoTests: PipeableXCTestCase {
             page
         )
     }
+
+    func testGotoTestResponseHeaders() async throws {
+        let page = PipeablePage(webView)
+
+        let response = try await runScript(
+            """
+            return await page.goto("\(testServerURL)/header_test", { timeout: 2_000, waitUntil: "domcontentloaded" });
+            """,
+            page
+        )
+
+        // swiftlint:disable force_cast
+
+        let resultDict = response.toDictionary()
+        XCTAssertEqual(resultDict?["status"] as! Int, 200)
+
+        let headers = resultDict?["headers"] as! [AnyHashable: Any] as [AnyHashable: Any]
+        XCTAssertEqual(headers["Content-Type"] as! NSString, "text/html; charset=utf-8")
+        XCTAssertEqual(headers["X-Test-Header"] as! NSString, "Test")
+
+        // swiftlint:enable force_cast
+    }
 }

--- a/PipeableTests/ScriptSerializerTests.swift
+++ b/PipeableTests/ScriptSerializerTests.swift
@@ -58,6 +58,26 @@ final class ScriptSerializerTests: XCTestCase {
         XCTAssertEqual(array?[2] as! Int, 3)
     }
 
+    func testSerializeInt() throws {
+        let value = 5
+        let jsValue = try serializeToJSValue(value, self.context)
+
+        XCTAssertTrue(jsValue.isNumber)
+
+        let number = jsValue.toNumber()
+        XCTAssertEqual(number, 5)
+    }
+
+    func testSerializeString() throws {
+        let value = "test"
+        let jsValue = try serializeToJSValue(value, self.context)
+
+        XCTAssertTrue(jsValue.isString)
+
+        let number = jsValue.toString()
+        XCTAssertEqual(number, "test")
+    }
+
     func testSerializeAClassWithComplexProperties() throws {
         class SimpleStruct {
             public var string = "test"

--- a/PipeableTests/ScriptSerializerTests.swift
+++ b/PipeableTests/ScriptSerializerTests.swift
@@ -1,0 +1,99 @@
+import JavaScriptCore
+@testable import PipeableSDK
+import XCTest
+
+// swiftlint:disable force_cast
+
+final class ScriptSerializerTests: XCTestCase {
+    // swiftlint:disable implicitly_unwrapped_optional
+    var context: JSContext!
+
+    override func setUp() {
+        super.setUp()
+
+        self.context = JSContext()
+    }
+
+    func testSerializeASimpleStruct() throws {
+        struct SimpleStruct {
+            public var int: Int
+            public var string: String
+        }
+
+        let value = SimpleStruct(int: 42, string: "test")
+        let jsValue = try serializeToJSValue(value, self.context)
+
+        XCTAssertTrue(jsValue.isObject)
+
+        let dict = jsValue.toDictionary()
+        XCTAssertEqual(dict?["int"] as! Int, 42)
+        XCTAssertEqual(dict?["string"] as! String, "test")
+    }
+
+    func testSerializeASimpleClass() throws {
+        class SimpleClass {
+            public var int = 42
+            public var string = "test"
+        }
+
+        let value = SimpleClass()
+        let jsValue = try serializeToJSValue(value, self.context)
+
+        XCTAssertTrue(jsValue.isObject)
+
+        let dict = jsValue.toDictionary()
+        XCTAssertEqual(dict?["int"] as! Int, 42)
+        XCTAssertEqual(dict?["string"] as! String, "test")
+    }
+
+    func testSerializeAnArray() throws {
+        let value = [1, 2, 3]
+        let jsValue = try serializeToJSValue(value, self.context)
+
+        XCTAssertTrue(jsValue.isArray)
+
+        let array = jsValue.toArray()
+        XCTAssertEqual(array?[0] as! Int, 1)
+        XCTAssertEqual(array?[1] as! Int, 2)
+        XCTAssertEqual(array?[2] as! Int, 3)
+    }
+
+    func testSerializeAClassWithComplexProperties() throws {
+        class SimpleStruct {
+            public var string = "test"
+        }
+        class SimpleClass {
+            public var int = 6
+        }
+        class ComplexClass {
+            public var int = 42
+            public var string: String?
+            public var array = [1, 2]
+            public var dict = ["test": 1]
+            public var simpleStruct = SimpleStruct()
+            public var simpleClass = SimpleClass()
+        }
+
+        let value = ComplexClass()
+        let jsValue = try serializeToJSValue(value, self.context)
+
+        XCTAssertTrue(jsValue.isObject)
+
+        let complexClass = jsValue.toDictionary()
+        XCTAssertEqual(complexClass?["int"] as! Int, 42)
+        XCTAssertEqual(complexClass?["string"] as! NSNull, NSNull())
+
+        let array = complexClass?["array"] as! [Int]
+        XCTAssertEqual(array[0], 1)
+        XCTAssertEqual(array[1], 2)
+
+        let dict = complexClass?["dict"] as! [String: Any]
+        XCTAssertEqual(dict["test"] as! Int, 1)
+
+        let simpleStruct = complexClass?["simpleStruct"] as! [String: Any]
+        XCTAssertEqual(simpleStruct["string"] as! String, "test")
+
+        let simpleClass = complexClass?["simpleClass"] as! [String: Any]
+        XCTAssertEqual(simpleClass["int"] as! Int, 6)
+    }
+}

--- a/PipeableTests/ScriptTests.swift
+++ b/PipeableTests/ScriptTests.swift
@@ -1,15 +1,23 @@
+import JavaScriptCore
 @testable import PipeableSDK
 import XCTest
+
+// swiftlint:disable force_cast
 
 final class ScriptTests: XCTestCase {
     func testGoto() async throws {
         let result = try await runScript("""
             print('Calling page.goto');
-            await fakePage.goto("https://google.com");
-            return true;
+            let response = await fakePage.goto("https://google.com");
+            return response;
         """)
 
-        XCTAssertTrue(result.isBoolean && result.toBool(), "Unexpected result! " + result.debugDescription)
+        XCTAssertTrue(result.isObject, "Unexpected result! " + result.debugDescription)
+        let resultDict = result.toDictionary()
+        XCTAssertEqual(resultDict?["status"] as! Int, 200)
+        let headers = resultDict?["headers"] as! [AnyHashable: Any] as [AnyHashable: Any]
+        XCTAssertEqual(headers["Connection"] as! NSString, "Keep-Alive")
+        XCTAssertEqual(headers["Content-Encoding"] as! NSString, "gzip")
     }
 
     func testGotoWithError() async throws {

--- a/Sources/PipeableSDK/Script/PageWrapper.swift
+++ b/Sources/PipeableSDK/Script/PageWrapper.swift
@@ -26,8 +26,8 @@ final class PageWrapper: BaseWrapper, PageJSExport {
                 throw PipeableError.invalidParameter("Invalid waitUntil option passed: \(waitUntilRaw)")
             }
 
-            _ = try await self.page.goto(url, waitUntil: waitUntil, timeout: timeout)
-            return CompletionResult.success(nil)
+            let response = try await self.page.goto(url, waitUntil: waitUntil, timeout: timeout)
+            return CompletionResult.success(try serializeToJSValue(response, self.context))
         }
     }
 

--- a/Sources/PipeableSDK/Script/Script.swift
+++ b/Sources/PipeableSDK/Script/Script.swift
@@ -31,7 +31,7 @@ public func prepareJSContext(_ dispatchGroup: DispatchGroup, _ page: PipeablePag
         }
     }
 
-    let fakePage = FakePageWrapper(dispatchGroup)
+    let fakePage = FakePageWrapper(dispatchGroup, context)
     let scriptContext = ScriptContext(dispatchGroup)
 
     context.setObject(scriptContext, forKeyedSubscript: "__context" as (NSCopying & NSObjectProtocol))

--- a/Sources/PipeableSDK/Script/SerializeToDictionary.swift
+++ b/Sources/PipeableSDK/Script/SerializeToDictionary.swift
@@ -1,0 +1,58 @@
+import Foundation
+import JavaScriptCore
+
+private func objectToDictionary<T>(_ object: T) -> [String: Any] {
+    let mirror = Mirror(reflecting: object)
+    var dictionary: [String: Any] = [:]
+
+    for case let (label?, value) in mirror.children {
+        dictionary[label] = unwrap(value)
+    }
+
+    return dictionary
+}
+
+/// Helper function to unwrap any potential Optional value.
+/// It recursively unwraps optionals to ensure the actual value is extracted,
+/// and handles conversion of nested objects and collections to dictionaries.
+private func unwrap(_ any: Any) -> Any {
+    let mirror = Mirror(reflecting: any)
+    if mirror.displayStyle != .optional {
+        return convertValue(any)
+    }
+
+    if mirror.children.isEmpty { return NSNull() }
+    // swiftlint:disable:next force_unwrapping
+    let (_, some) = mirror.children.first!
+    return unwrap(some)
+}
+
+/// Convert value to a compatible format, handling specific types like arrays and nested objects.
+private func convertValue(_ value: Any) -> Any {
+    let mirror = Mirror(reflecting: value)
+    switch mirror.displayStyle {
+    case .collection:
+        // swiftlint:disable:next force_cast
+        return (value as! [Any]).map { unwrap($0) }
+    case .dictionary:
+        var dict: [AnyHashable: Any] = [:]
+        // swiftlint:disable:next all
+        for case let (key, v) in value as! [AnyHashable: Any] {
+            dict[key] = unwrap(v)
+        }
+        return dict
+    case .struct, .class:
+        return objectToDictionary(value)
+    default:
+        return value
+    }
+}
+
+// Serializes a struct or class to JSValue object.
+func serializeToJSValue(_ object: Any?, _ context: JSContext) throws -> JSValue {
+    if let object = object {
+        let dictionary = objectToDictionary(object)
+        return JSValue(object: dictionary, in: context)
+    }
+    return JSValue(nullIn: context)
+}

--- a/Sources/PipeableSDK/Script/Serializer.swift
+++ b/Sources/PipeableSDK/Script/Serializer.swift
@@ -1,7 +1,7 @@
 import Foundation
 import JavaScriptCore
 
-private func objectToDictionary<T>(_ object: T) -> [String: Any] {
+private func objectToDictionary(_ object: Any) -> [String: Any] {
     let mirror = Mirror(reflecting: object)
     var dictionary: [String: Any] = [:]
 
@@ -48,11 +48,11 @@ private func convertValue(_ value: Any) -> Any {
     }
 }
 
-// Serializes a struct or class to JSValue object.
-func serializeToJSValue(_ object: Any?, _ context: JSContext) throws -> JSValue {
-    if let object = object {
-        let dictionary = objectToDictionary(object)
-        return JSValue(object: dictionary, in: context)
+// Serializes a struct, class, array or dictionary to JSValue.
+func serializeToJSValue(_ value: Any?, _ context: JSContext) throws -> JSValue {
+    if let value = value {
+        let converted = convertValue(value)
+        return JSValue(object: converted, in: context)
     }
     return JSValue(nullIn: context)
 }


### PR DESCRIPTION
Serialize to a Dictionary and use that to pass it to JavaScriptCore JSValue. This seems to work fine and is simple to implement.