### PR TITLE
PipeablePage: hide constructor and expose convenience initializer without WKFrameInfo

### DIFF
--- a/Sources/PipeableSDK/PipeablePage.swift
+++ b/Sources/PipeableSDK/PipeablePage.swift
@@ -94,7 +94,11 @@ public class PipeablePage {
         case networkidle
     }
 
-    public init(_ webView: WKWebView, _ frame: WKFrameInfo? = nil, debugPrintConsoleLogs: Bool? = nil) {
+    public convenience init(_ webView: WKWebView, debugPrintConsoleLogs: Bool? = nil) {
+        self.init(webView, nil, debugPrintConsoleLogs: debugPrintConsoleLogs)
+    }
+
+    init(_ webView: WKWebView, _ frame: WKFrameInfo? = nil, debugPrintConsoleLogs: Bool? = nil) {
         self.webView = webView
         self.frame = frame
 


### PR DESCRIPTION
`WKFrameInfo` is a hidden implementation detail and shouldn't be exposed to the public API.