### PR TITLE
PipeablePage.waitForURL added an option to ignore navigation errors

### DIFF
--- a/PipeableSDK.xcodeproj/project.pbxproj
+++ b/PipeableSDK.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		A4A7A9262B56BD7500982E63 /* Pipeable.docc in Sources */ = {isa = PBXBuildFile; fileRef = A4A7A9252B56BD7500982E63 /* Pipeable.docc */; };
 		A4A7A9312B56BD7500982E63 /* PipeableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4A7A9302B56BD7500982E63 /* PipeableTests.swift */; };
 		A4A7A9322B56BD7500982E63 /* Pipeable.h in Headers */ = {isa = PBXBuildFile; fileRef = A4A7A9242B56BD7500982E63 /* Pipeable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A4A9E0CB2BAB1CDC007FA2ED /* PipeablePage+Selectors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4A9E0CA2BAB1CDC007FA2ED /* PipeablePage+Selectors.swift */; };
 		A4CA67792BA87F61004ABE90 /* PipeableWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CA67782BA87F61004ABE90 /* PipeableWebView.swift */; };
 		A4DF83B52B8CD0B3000EFCEA /* PipeablePageDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4DF83B42B8CD0B3000EFCEA /* PipeablePageDelegate.swift */; };
 		A4FF74BE2BA352E90046936C /* pipeable.js in Resources */ = {isa = PBXBuildFile; fileRef = A4FF74BD2BA352E90046936C /* pipeable.js */; };
@@ -69,6 +70,7 @@
 		A4A7A9252B56BD7500982E63 /* Pipeable.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Pipeable.docc; sourceTree = "<group>"; };
 		A4A7A92B2B56BD7500982E63 /* PipeableSDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PipeableSDKTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A4A7A9302B56BD7500982E63 /* PipeableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipeableTests.swift; sourceTree = "<group>"; };
+		A4A9E0CA2BAB1CDC007FA2ED /* PipeablePage+Selectors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PipeablePage+Selectors.swift"; sourceTree = "<group>"; };
 		A4CA67782BA87F61004ABE90 /* PipeableWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipeableWebView.swift; sourceTree = "<group>"; };
 		A4DF83B42B8CD0B3000EFCEA /* PipeablePageDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipeablePageDelegate.swift; sourceTree = "<group>"; };
 		A4FF74BD2BA352E90046936C /* pipeable.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = pipeable.js; sourceTree = "<group>"; };
@@ -172,6 +174,7 @@
 				A43DC5892B7277C100D0670B /* PipeableElement.swift */,
 				A4A7A9252B56BD7500982E63 /* Pipeable.docc */,
 				A434C6152B5964B300B8011C /* PipeablePage.swift */,
+				A4A9E0CA2BAB1CDC007FA2ED /* PipeablePage+Selectors.swift */,
 				A478D6C32B98B594000B11CC /* PipeablePage+Evaluate.swift */,
 				A4DF83B42B8CD0B3000EFCEA /* PipeablePageDelegate.swift */,
 				E8AC39A12B615BC900D413BF /* Script */,
@@ -362,6 +365,7 @@
 				E81BD5AE2B6D430A007DFC02 /* PageWrapper.swift in Sources */,
 				E81BD5B02B6D45B6007DFC02 /* ElementWrapper.swift in Sources */,
 				A434C6162B5964B300B8011C /* PipeablePage.swift in Sources */,
+				A4A9E0CB2BAB1CDC007FA2ED /* PipeablePage+Selectors.swift in Sources */,
 				E8C2784F2B8E0D9100B8B176 /* Serializer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PipeableTests/PipeablePage_GotoTests.swift
+++ b/PipeableTests/PipeablePage_GotoTests.swift
@@ -146,7 +146,12 @@ final class PipeablePageGotoTests: PipeableXCTestCase {
             )
         } catch {
             if let error = error as? PipeableError {
-                if case PipeableError.navigationError = error {
+                if case PipeableError.navigationError(let reason) = error {
+                    XCTAssert(
+                        reason.contains("Could not connect to the server"),
+                        "Failed with unexpected error \(reason))"
+                    )
+
                     return
                 } else {
                     XCTFail("Unexpected error \(error)")

--- a/Sources/PipeableSDK/PipeableElement.swift
+++ b/Sources/PipeableSDK/PipeableElement.swift
@@ -63,7 +63,7 @@ public class PipeableElement {
 
     // TODO: this should be frame, not page here I thinks -- we need to separate those. Maybe Page extends frame -- yes!
     public func contentFrame() async throws -> PipeablePage? {
-        let requestId = randomString(length: 10)
+        let requestId = UUID().uuidString
         let result = try await page.webView.callAsyncJavaScript(
             """
                 return window.PipeableJS.sendFrameIDMessage(elementHash, requestId);

--- a/Sources/PipeableSDK/PipeablePage+Selectors.swift
+++ b/Sources/PipeableSDK/PipeablePage+Selectors.swift
@@ -1,0 +1,105 @@
+import Foundation
+import WebKit
+
+public extension PipeablePage {
+    func querySelector(_ selector: String) async throws -> PipeableElement? {
+        let result = try await webView.callAsyncJavaScript(
+            """
+                return window.PipeableJS.$(selector);
+            """,
+            arguments: ["selector": selector],
+            in: frame,
+            contentWorld: WKContentWorld.page
+        )
+
+        if let elementId = result as? String {
+            return PipeableElement(self, elementId)
+        }
+
+        return nil
+    }
+
+    func querySelectorAll(_ selector: String) async throws -> [PipeableElement] {
+        let result = try await webView.callAsyncJavaScript(
+            """
+                return window.PipeableJS.$$(selector);
+            """,
+            arguments: ["selector": selector],
+            in: frame,
+            contentWorld: WKContentWorld.page
+        )
+
+        if let elementIds = result as? [String] {
+            return elementIds.map { (elementId: String) -> PipeableElement in
+                PipeableElement(self, elementId)
+            }
+        }
+
+        return []
+    }
+
+    func xpathSelector(_ xpath: String) async throws -> [PipeableElement] {
+        let result = try await webView.callAsyncJavaScript(
+            """
+                return window.PipeableJS.$x(xpath);
+            """,
+            arguments: ["xpath": xpath],
+            in: frame,
+            contentWorld: WKContentWorld.page
+        )
+
+        if let elementIds = result as? [String] {
+            return elementIds.map { (elementId: String) -> PipeableElement in
+                PipeableElement(self, elementId)
+            }
+        }
+
+        return []
+    }
+
+    func waitForXPath(_ xpath: String, timeout: Int = 30000, visible: Bool = false) async throws -> PipeableElement? {
+        let result = try await webView.callAsyncJavaScript(
+            """
+                return window.PipeableJS.waitForXPath(xpath, opts);
+            """,
+            arguments: [
+                "xpath": xpath,
+                "opts": [
+                    "timeout": String(timeout),
+                    "visible": visible,
+                ] as [String: Any],
+            ],
+            in: frame,
+            contentWorld: WKContentWorld.page
+        )
+
+        if let elementId = result as? String {
+            return PipeableElement(self, elementId)
+        }
+
+        return nil
+    }
+
+    func waitForSelector(_ selector: String, timeout: Int = 30000, visible: Bool = false) async throws -> PipeableElement? {
+        let result = try await webView.callAsyncJavaScript(
+            """
+                return window.PipeableJS.waitForSelector(selector, opts);
+            """,
+            arguments: [
+                "selector": selector,
+                "opts": [
+                    "timeout": String(timeout),
+                    "visible": visible,
+                ] as [String: Any],
+            ],
+            in: frame,
+            contentWorld: WKContentWorld.page
+        )
+
+        if let elementId = result as? String {
+            return PipeableElement(self, elementId)
+        }
+
+        return nil
+    }
+}

--- a/Sources/PipeableSDK/PipeablePage.swift
+++ b/Sources/PipeableSDK/PipeablePage.swift
@@ -243,7 +243,13 @@ public class PipeablePage {
         )
     }
 
-    // TODO: Implement shorthards for predicates -- string matching, regex matching
+    /// Waits for the WebView to navigate to a URL that matches the given predicate.
+    /// - Parameters:
+    /// - predicate: A closure that takes a URL and returns a boolean.
+    /// - waitUntil: When to consider navigation as finished, defaults to `.load`.
+    /// - timeout: Maximum time to wait for the navigation to finish, defaults to 30000ms.
+    /// - ignoreNavigationErrors: If true, ignores navigation errors and waits for the URL to match the predicate.
+    /// - Throws: PipeableError.navigationError if the navigation fails and ignoreNavigationErrors is false.
     public func waitForURL(
         _ predicate: @escaping (String) -> Bool,
         waitUntil: WaitUntilOption = .load,

--- a/Sources/PipeableSDK/PipeablePage.swift
+++ b/Sources/PipeableSDK/PipeablePage.swift
@@ -1,9 +1,6 @@
 import Foundation
 import WebKit
 
-// swiftlint:disable type_body_length
-// swiftlint:disable file_length
-
 public class PipeablePage {
     var webView: WKWebView
     var frame: WKFrameInfo?
@@ -264,107 +261,6 @@ public class PipeablePage {
         )
     }
 
-    public func querySelector(_ selector: String) async throws -> PipeableElement? {
-        let result = try await webView.callAsyncJavaScript(
-            """
-                return window.PipeableJS.$(selector);
-            """,
-            arguments: ["selector": selector],
-            in: frame,
-            contentWorld: WKContentWorld.page
-        )
-
-        if let elementId = result as? String {
-            return PipeableElement(self, elementId)
-        }
-
-        return nil
-    }
-
-    public func querySelectorAll(_ selector: String) async throws -> [PipeableElement] {
-        let result = try await webView.callAsyncJavaScript(
-            """
-                return window.PipeableJS.$$(selector);
-            """,
-            arguments: ["selector": selector],
-            in: frame,
-            contentWorld: WKContentWorld.page
-        )
-
-        if let elementIds = result as? [String] {
-            return elementIds.map { (elementId: String) -> PipeableElement in
-                PipeableElement(self, elementId)
-            }
-        }
-
-        return []
-    }
-
-    public func xpathSelector(_ xpath: String) async throws -> [PipeableElement] {
-        let result = try await webView.callAsyncJavaScript(
-            """
-                return window.PipeableJS.$x(xpath);
-            """,
-            arguments: ["xpath": xpath],
-            in: frame,
-            contentWorld: WKContentWorld.page
-        )
-
-        if let elementIds = result as? [String] {
-            return elementIds.map { (elementId: String) -> PipeableElement in
-                PipeableElement(self, elementId)
-            }
-        }
-
-        return []
-    }
-
-    public func waitForXPath(_ xpath: String, timeout: Int = 30000, visible: Bool = false) async throws -> PipeableElement? {
-        let result = try await webView.callAsyncJavaScript(
-            """
-                return window.PipeableJS.waitForXPath(xpath, opts);
-            """,
-            arguments: [
-                "xpath": xpath,
-                "opts": [
-                    "timeout": String(timeout),
-                    "visible": visible,
-                ] as [String: Any],
-            ],
-            in: frame,
-            contentWorld: WKContentWorld.page
-        )
-
-        if let elementId = result as? String {
-            return PipeableElement(self, elementId)
-        }
-
-        return nil
-    }
-
-    public func waitForSelector(_ selector: String, timeout: Int = 30000, visible: Bool = false) async throws -> PipeableElement? {
-        let result = try await webView.callAsyncJavaScript(
-            """
-                return window.PipeableJS.waitForSelector(selector, opts);
-            """,
-            arguments: [
-                "selector": selector,
-                "opts": [
-                    "timeout": String(timeout),
-                    "visible": visible,
-                ] as [String: Any],
-            ],
-            in: frame,
-            contentWorld: WKContentWorld.page
-        )
-
-        if let elementId = result as? String {
-            return PipeableElement(self, elementId)
-        }
-
-        return nil
-    }
-
     public func waitForXHR(_ url: String, timeout: Int = 30000) async throws -> XHRResult? {
         let result = try await webView.callAsyncJavaScript(
             """
@@ -464,10 +360,4 @@ enum PipeableError: Error {
     case invalidParameter(String)
     case fatalError(String)
     case initializationError
-}
-
-func randomString(length: Int) -> String {
-    let characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-    // swiftlint:disable:next force_unwrapping
-    return String((0 ..< length).map { _ in characters.randomElement()! })
 }

--- a/Sources/PipeableSDK/PipeablePage.swift
+++ b/Sources/PipeableSDK/PipeablePage.swift
@@ -257,7 +257,8 @@ public class PipeablePage {
                     return false
                 }
             },
-            timeout: timeout
+            timeout: timeout,
+            ignoreNavigationErrors: true
         )
     }
 

--- a/Sources/PipeableSDK/PipeablePage.swift
+++ b/Sources/PipeableSDK/PipeablePage.swift
@@ -247,7 +247,8 @@ public class PipeablePage {
     public func waitForURL(
         _ predicate: @escaping (String) -> Bool,
         waitUntil: WaitUntilOption = .load,
-        timeout: Int = 30000
+        timeout: Int = 30000,
+        ignoreNavigationErrors: Bool = false
     ) async throws {
         try await pageLoadState.waitForLoadStateChange(
             predicate: { state, url in
@@ -258,7 +259,7 @@ public class PipeablePage {
                 }
             },
             timeout: timeout,
-            ignoreNavigationErrors: true
+            ignoreNavigationErrors: ignoreNavigationErrors
         )
     }
 

--- a/Sources/PipeableSDK/PipeablePageDelegate.swift
+++ b/Sources/PipeableSDK/PipeablePageDelegate.swift
@@ -28,12 +28,11 @@ class PipeablePageDelegate: NSObject, WKNavigationDelegate {
         )
     }
 
-    func webView(_: WKWebView, didFailProvisionalNavigation _: WKNavigation, withError _: Error) {
-        // TODO: Figure out how to deal with Apple Login...
-//        loadPageState.error(
-//            error: PipeableError.navigationError(error.localizedDescription),
-//            url: webView.url?.absoluteString
-//        )
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation _: WKNavigation, withError error: Error) {
+        loadPageState.error(
+            error: PipeableError.navigationError(error.localizedDescription),
+            url: webView.url?.absoluteString
+        )
     }
 
     func webView(_: WKWebView, didReceive _: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {


### PR DESCRIPTION
Added an option to ignore navigation errors while waiting for url.
`page.waitForURL(predicate, timeout, ignoreNavigationErrors)`

The goal is to facilitate "Login with Apple" with FaceID, which results in a number of navigation errors (Frame load interrupted) and thus waitign for login with `waitForURL` is trickier to implement.

The default value is `false` and errors are reported by default.

Closes #58 